### PR TITLE
Remove unused scrollbar

### DIFF
--- a/pinentry-rofi.scm
+++ b/pinentry-rofi.scm
@@ -316,7 +316,7 @@ Return the input from the user if succeeded else #f."
          (rofi-sh `("env"
                     ,(string-join
                       (map (lambda (x) (format #f "~a=~s" (car x) (cdr x))) env))
-                    ,(format #f "rofi -dmenu -disable-history -l ~a -i"
+                    ,(format #f "rofi -dmenu -disable-history -no-fixed-num-lines -l ~a -i"
                              (if (list? buttons) (length buttons) 1))
                     ,(if (and only-match buttons) "-only-match" "")
                     ,(if (not buttons) "-input /dev/null" "")


### PR DESCRIPTION
There is a scrollbar, if there are no options available:

## Before
![2023-12-06_22-47](https://github.com/plattfot/pinentry-rofi/assets/26086452/ea904dae-5993-4294-949b-b4a806bbe6b6)

This is fixed by passing this argument to rofi.
## After
![2023-12-06_22-45](https://github.com/plattfot/pinentry-rofi/assets/26086452/8b5bc77a-4d69-49f6-a9b4-c249f7bc7817)

Tested on rofi `1.7.5`