### PR TITLE
Mimic cli options to be compatible with `rbw`

### DIFF
--- a/scripts/pinentry-rofi.in
+++ b/scripts/pinentry-rofi.in
@@ -21,9 +21,16 @@
           '((display (single-char #\D) (value #t))
             (xauthority (single-char #\a) (value #t))
             (version (single-char #\v) (value #f))
+            (debug (single-char #\d) (value #f))
+            (ttyname (single-char #\T) (value #t))
+            (ttytype (single-char #\N) (value #t))
             (lc-ctype (single-char #\C) (value #t))
             (lc-message (single-char #\M) (value #t))
+            (timeout (single-char #\o) (value #t))
             (no-global-grab (single-char #\g) (value #f))
+            (parent-wid (single-char #\W) (value #f))
+            (colors (single-char #\c) (value #f))
+            (ttyalert (single-char #\a) (value #f))
             (log (value #t))
             (help (single-char #\h) (value #f))))
          (default-display ":0")
@@ -54,6 +61,14 @@ Options:
   -M, --lc-messages STRING   Set the tty LC_MESSAGES value
   -g, --no-global-grab       Grab keyboard only while window is focused
   -- [ROFI-OPTIONS]...  Options after -- will be sent to rofi
+Dummy options (does not do anything just for compatibility):
+  -d, --debug                Turn on debugging output
+  -T, --ttyname FILE         Set the tty terminal node name
+  -N, --ttytype NAME         Set the tty terminal type
+  -o, --timeout SECS         Timeout waiting for input after this many seconds
+  -W, --parent-wid           Parent window ID (for positioning)
+  -c, --colors STRING        Set custom colors for ncurses
+  -a, --ttyalert STRING      Set the alert mode (none, beep or flash)
 Author:
 ~a
 "
@@ -61,6 +76,17 @@ Author:
               default-display
               @AUTHOR@)
       (exit #t))
+    (let ((unimplemented (lambda (option)
+                           (when (option-ref options option #f)
+                             (format (current-error-port) "warning: --~a is not implemented~%"
+                                     (symbol->string option))))))
+      (unimplemented 'debug)
+      (unimplemented 'ttyname)
+      (unimplemented 'ttytype)
+      (unimplemented 'timeout)
+      (unimplemented 'parent-wid)
+      (unimplemented 'colors)
+      (unimplemented 'ttyalert))
     (when (option-ref options 'version #f)
       (format #t "~a~%" @HVERSION@)
       (exit #t))

--- a/scripts/pinentry-rofi.in
+++ b/scripts/pinentry-rofi.in
@@ -18,7 +18,7 @@
              (pinentry-rofi))
 (define (main args)
   (let* ((option-spec
-          '((display (single-char #\d) (value #t))
+          '((display (single-char #\D) (value #t))
             (xauthority (single-char #\a) (value #t))
             (version (single-char #\v) (value #f))
             (log (value #t))
@@ -38,7 +38,7 @@
       (format #t "\
 Usage: ~a [OPTIONS]...
 Options:
-  -d, --display DISPLAY Set display, default is ~s.
+  -D, --display DISPLAY Set display, default is ~s.
       --log LOGFILE     Log unknown commands to LOGFILE
   -v, --version         Display version.
   -h, --help            Display this help.

--- a/scripts/pinentry-rofi.in
+++ b/scripts/pinentry-rofi.in
@@ -38,7 +38,7 @@
       (format #t "\
 Usage: ~a [OPTIONS]...
 Options:
-  -D, --display DISPLAY      Set display, default is ~s.
+  -D, --display DISPLAY      Set display, default is ~s
       --log LOGFILE          Log unknown commands to LOGFILE
   -v, --version              Display version.
   -h, --help                 Display this help.

--- a/scripts/pinentry-rofi.in
+++ b/scripts/pinentry-rofi.in
@@ -21,9 +21,11 @@
           '((display (single-char #\D) (value #t))
             (xauthority (single-char #\a) (value #t))
             (version (single-char #\v) (value #f))
+            (lc-ctype (single-char #\C) (value #t))
             (log (value #t))
             (help (single-char #\h) (value #f))))
          (default-display ":0")
+         (default-lc-ctype "C")
          (options (getopt-long (command-line) option-spec))
          (pinentry (make-pinentry #t "Passphrase:" "Ok" "Cancel"
                                   (option-ref options 'display default-display)
@@ -31,7 +33,7 @@
                                     (when logfile
                                       (open-output-file
                                        (format #f "~a.~a" logfile (getpid)))))
-                                  "C"
+                                  (option-ref options 'lc-ctype default-lc-ctype)
                                   "C"
                                   (option-ref options '() '()))))
     (when (option-ref options 'help #f)
@@ -42,6 +44,7 @@ Options:
       --log LOGFILE          Log unknown commands to LOGFILE
   -v, --version              Display version.
   -h, --help                 Display this help.
+  -C, --lc-ctype STRING      Set the tty LC_CTYPE value
   -- [ROFI-OPTIONS]...  Options after -- will be sent to rofi
 Author:
 ~a

--- a/scripts/pinentry-rofi.in
+++ b/scripts/pinentry-rofi.in
@@ -23,6 +23,7 @@
             (version (single-char #\v) (value #f))
             (lc-ctype (single-char #\C) (value #t))
             (lc-message (single-char #\M) (value #t))
+            (no-global-grab (single-char #\g) (value #f))
             (log (value #t))
             (help (single-char #\h) (value #f))))
          (default-display ":0")
@@ -37,7 +38,10 @@
                                        (format #f "~a.~a" logfile (getpid)))))
                                   (option-ref options 'lc-ctype default-lc-ctype)
                                   (option-ref options 'lc-message default-lc-message)
-                                  (option-ref options '() '()))))
+                                  (option-ref options '()
+                                              (if (option-ref options 'no-global-grab #f)
+                                                    '("-no-lazy-grab")
+                                                    '())))))
     (when (option-ref options 'help #f)
       (format #t "\
 Usage: ~a [OPTIONS]...
@@ -48,6 +52,7 @@ Options:
   -h, --help                 Display this help.
   -C, --lc-ctype STRING      Set the tty LC_CTYPE value
   -M, --lc-messages STRING   Set the tty LC_MESSAGES value
+  -g, --no-global-grab       Grab keyboard only while window is focused
   -- [ROFI-OPTIONS]...  Options after -- will be sent to rofi
 Author:
 ~a

--- a/scripts/pinentry-rofi.in
+++ b/scripts/pinentry-rofi.in
@@ -22,10 +22,12 @@
             (xauthority (single-char #\a) (value #t))
             (version (single-char #\v) (value #f))
             (lc-ctype (single-char #\C) (value #t))
+            (lc-message (single-char #\M) (value #t))
             (log (value #t))
             (help (single-char #\h) (value #f))))
          (default-display ":0")
          (default-lc-ctype "C")
+         (default-lc-message "C")
          (options (getopt-long (command-line) option-spec))
          (pinentry (make-pinentry #t "Passphrase:" "Ok" "Cancel"
                                   (option-ref options 'display default-display)
@@ -34,7 +36,7 @@
                                       (open-output-file
                                        (format #f "~a.~a" logfile (getpid)))))
                                   (option-ref options 'lc-ctype default-lc-ctype)
-                                  "C"
+                                  (option-ref options 'lc-message default-lc-message)
                                   (option-ref options '() '()))))
     (when (option-ref options 'help #f)
       (format #t "\
@@ -45,6 +47,7 @@ Options:
   -v, --version              Display version.
   -h, --help                 Display this help.
   -C, --lc-ctype STRING      Set the tty LC_CTYPE value
+  -M, --lc-messages STRING   Set the tty LC_MESSAGES value
   -- [ROFI-OPTIONS]...  Options after -- will be sent to rofi
 Author:
 ~a

--- a/scripts/pinentry-rofi.in
+++ b/scripts/pinentry-rofi.in
@@ -38,10 +38,10 @@
       (format #t "\
 Usage: ~a [OPTIONS]...
 Options:
-  -D, --display DISPLAY Set display, default is ~s.
-      --log LOGFILE     Log unknown commands to LOGFILE
-  -v, --version         Display version.
-  -h, --help            Display this help.
+  -D, --display DISPLAY      Set display, default is ~s.
+      --log LOGFILE          Log unknown commands to LOGFILE
+  -v, --version              Display version.
+  -h, --help                 Display this help.
   -- [ROFI-OPTIONS]...  Options after -- will be sent to rofi
 Author:
 ~a


### PR DESCRIPTION
Implementing the request for #23.

I did not implement an action for all of the missing standard options.

Only added for:
```
  -C, --lc-ctype STRING      Set the tty LC_CTYPE value
  -M, --lc-messages STRING   Set the tty LC_MESSAGES value
  -g, --no-global-grab       Grab keyboard only while window is focused
```

The rest I just added as dummy options to avoid erroring out.

Also this changes the short option for `--display` to `-D` instead of `-d`. The latter is now used for the dummy option `--debug`.