### PR TITLE
Encode password before handing it to gpg

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,6 +16,26 @@
   I also wanted a small project which I could use to practice writing
   GNU guile.
 
+* 3.0.0 Breaking changes please read
+
+  There is a major bug in pinentry-rofi 2.2.0 and below.  The password
+  was not encoded before giving it to gpg.  Which meant that passwords
+  including character other than alphanumerics from ASCII and `-`,
+  `.`, `_` and `~` ended up being decoded on gpg's side.  Making them
+  not match the input and therefore not work on other pinentry tools.
+  See [[https://github.com/plattfot/pinentry-rofi/issues/27][#27]] for details.
+
+  Before moving to pinentry-rofi-3.0.0, please make sure to
+  temporarily change the passwords affected by this bug to something
+  that does not include those special characters.  Make the upgrade
+  then change back.
+
+  An alternative is to figure out what gnupg decoded the passwords too
+  and use that as the input when using pinentry-rofi-3.0.0.  And
+  change the passwords to match what they where suppose to be.
+
+  Sorry for the headaches.
+
 * 2.0.0 Breaking changes please read
 
   As of version 2.0.0, =pinentry-rofi= is now built using [[https://www.gnu.org/software/automake][automake]].

--- a/pinentry-rofi.scm
+++ b/pinentry-rofi.scm
@@ -5,12 +5,13 @@
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 
 (define-module (pinentry-rofi)
+  #:use-module (ice-9 format)
   #:use-module (ice-9 popen)
+  #:use-module (ice-9 regex)
   #:use-module (ice-9 textual-ports)
   #:use-module (srfi srfi-1) ;; concatenate
   #:use-module (srfi srfi-9) ;; For records
-  #:use-module (ice-9 format)
-  #:use-module (ice-9 regex)
+  #:use-module (web uri)
   #:export (make-pinentry
             pinentry?
             pinentry-ok set-pinentry-ok!
@@ -374,7 +375,7 @@ Return the input from the user if succeeded else #f."
                                #:extra-options (pinentry-rofi-options pinentry))))
         (if (and pass (not (string-empty? (string-trim-both pass))))
             (begin
-              (format port "D ~a~!" pass)
+              (format port "D ~a~%~!" (uri-encode (string-trim-right pass #\newline)))
               (set-pinentry-ok! pinentry #t))
             (begin
               (format port "ERR 83886179 Operation cancelled <rofi>~%~!")

--- a/tests/pinentry-rofi.scm
+++ b/tests/pinentry-rofi.scm
@@ -480,4 +480,29 @@
   (test-assert (not (pinentry-getinfo pinentry " MESSAGE")))
   (test-assert (not (pinentry-getinfo pinentry "Foo"))))
 
+(let* ((pinentry (make-pinentry #f "Prompt" "Ok" "Cancel" ":1" "test.log" "C" "en_US.UTF-8" '()))
+       (output "")
+       (fake-port (make-soft-port
+                  (vector
+                   (lambda (c) (set! output (string-append output c)))
+                   (lambda (s) (set! output (string-append output s)))
+                   (lambda () #t)
+                   #f
+                   (lambda () #t))
+                  "w")))
+  (let ((passwords '("password"
+                     "Pass%word1"
+                     "1|Sb56(Qr=£?-N2GWjx>j=Ju+"
+                     "correct horse battery staple"))
+        (expectations '("password"
+                        "Pass%25word1"
+                        "1%7CSb56%28Qr%3D%C2%A3%3F-N2GWjx%3Ej%3DJu%2B"
+                        "correct%20horse%20battery%20staple")))
+    (for-each (lambda (password expected)
+                (test-assert (pinentry-getpin pinentry "GETPIN"
+                                              (lambda* _ (string-append password "\n"))
+                                              #:port fake-port))
+                (test-equal (format #f "D ~a~%" expected) output)
+                (set! output ""))
+              passwords expectations)))
 (test-end "pinentry-rofi")

--- a/tests/pinentry-rofi.scm
+++ b/tests/pinentry-rofi.scm
@@ -287,7 +287,7 @@
                                     env)
                                   "password")
                                 #:port fake-port))
-  (test-equal (format #f "D password") output)
+  (test-equal (format #f "D password~%") output)
   (set-pinentry-error! pinentry error)
   (set-pinentry-title! pinentry title)
   (set! output "")
@@ -315,7 +315,7 @@
                                     env)
                                   "password")
                                 #:port fake-port))
-  (test-equal (format #f "D password") output)
+  (test-equal (format #f "D password~%") output)
   (set! output "")
   (test-assert (pinentry-getpin pinentry "GETPIN"
                                 (lambda* (#:key (env '())


### PR DESCRIPTION
Addressing the bug described in #27.  Turns out that gpg expects the password given to it to be uri encoded. Which pinentry-rofi did not but do now.

This will however break users that used special characters in their password generated by `pinentry-rofi-2.2.0` or older.  I added a note in the readme about it and a recommendation on how to migrate.